### PR TITLE
Added read_davis_346() method

### DIFF
--- a/tonic/io.py
+++ b/tonic/io.py
@@ -127,6 +127,33 @@ def read_dvs_red(filename):
     return shape, xytp
 
 
+def read_davis_346(filename):
+    """
+    Get the aer events from DVS with resolution of (260, 346)
+
+    Parameters:
+        filename:   filename
+
+    Returns:
+        shape (tuple):
+            (height, width) of the sensor array
+
+        events: numpy structured array of events
+    """
+    data_version, data_start = read_aedat_header_from_file(filename)
+    all_events = get_aer_events_from_file(filename, data_version, data_start)
+    all_addr = all_events["address"]
+    t = all_events["timeStamp"]
+
+    x = (346 - 1) - ((all_addr & 4190208) >> 12)
+    y = ((all_addr & 2143289344) >> 22)
+    p = ((all_addr & 2048) >> 11)
+
+    xytp = make_structured_array(x, y, t, p)
+    shape = (346, 260)
+    return shape, xytp
+
+
 def read_dvs_346mini(filename):
     """
     Get the aer events from DVS with resolution of (132,104)

--- a/tonic/io.py
+++ b/tonic/io.py
@@ -129,7 +129,7 @@ def read_dvs_red(filename):
 
 def read_davis_346(filename):
     """
-    Get the aer events from DVS with resolution of (260, 346)
+    Get the aer events from DAVIS346 with resolution of (260, 346)
 
     Parameters:
         filename:   filename
@@ -145,8 +145,9 @@ def read_davis_346(filename):
     all_addr = all_events["address"]
     t = all_events["timeStamp"]
 
+    # x, y, and p : bit-shift and bit-mask values taken from jAER (https://github.com/SensorsINI/jaer)
     x = (346 - 1) - ((all_addr & 4190208) >> 12)
-    y = ((all_addr & 2143289344) >> 22)
+    y = (260 - 1) - ((all_addr & 2143289344) >> 22)
     p = ((all_addr & 2048) >> 11)
 
     xytp = make_structured_array(x, y, t, p)


### PR DESCRIPTION
I used this function to read event recordings as aedat files from DAVIS346 sensor of 346x260 resolution. I tried the existing read_dvs_red() method but noticed that the (x,y) pixel locations were beyond the resolution itself:
![Screenshot from 2023-09-01 11-07-06](https://github.com/Tobias-Fischer/tonic/assets/14059534/2f87940d-f199-4b19-aa1d-f9f465f3c0e1)
The bit mask and bit shift values used in the read_davis_346() method are taken from jAER (https://github.com/SensorsINI/jaer). jAER was used to record events into the aedat file too. The pixel locations look fine when reading from this function. I've also attached an event frame reconstructed from the events read from aedat recordings using the read_davis_346() method. 
![Screenshot from 2023-09-01 11-06-58](https://github.com/Tobias-Fischer/tonic/assets/14059534/e9e3fce5-d189-4fc4-9c27-e8df98816030)
![002 574](https://github.com/Tobias-Fischer/tonic/assets/14059534/5a6720f6-f98a-4569-a010-6e6a67fe73d2)